### PR TITLE
Fix warning about unused parameter

### DIFF
--- a/juice/variant.hpp
+++ b/juice/variant.hpp
@@ -640,7 +640,7 @@ namespace Juice
 
     template <typename U>
     result_type
-    operator()(const U& u) const
+    operator()(const U&) const
     {
       return nullptr;
     }


### PR DESCRIPTION
This patch makes juice compile without warnings.
