### PR TITLE
Allow for visitors to be passed as rvalues

### DIFF
--- a/juice/variant.hpp
+++ b/juice/variant.hpp
@@ -594,7 +594,7 @@ namespace Juice
 
     template <typename Visitor>
     typename Visitor::result_type
-    apply_visitor_internal(Visitor& visitor) const
+    apply_visitor_internal(Visitor&& visitor) const
     {
       return apply_visitor<MPL::true_, Visitor>(std::forward<Visitor>(visitor));
     }


### PR DESCRIPTION
This patch enables visitors to be passed as rvalues to `apply_visitor`.

Fixes #10.
