### PR TITLE
Make apply_visitor work with rvalues.

### DIFF
--- a/juice/variant.hpp
+++ b/juice/variant.hpp
@@ -643,7 +643,7 @@ namespace Juice
 
   template <typename Visitor, typename Visitable, typename... Args>
   typename std::remove_reference<Visitor>::type::result_type
-  apply_visitor(Visitor&& visitor, Visitable& visitable, Args&&... args)
+  apply_visitor(Visitor&& visitor, Visitable&& visitable, Args&&... args)
   {
     return visitable.template apply_visitor<MPL::false_>
       (std::forward<Visitor>(visitor), std::forward<Args>(args)...);


### PR DESCRIPTION
This patch adds support for rvalues in apply_visitor. For example, consider a visitor that computes a value from a temporary:

    auto x = apply_visitor(Visitor{}, Variant<int, double>{42});

Because `apply_visitor` took the visitable as an lvalue, the above statement would not compile.