### PR TITLE
Add missing template keyword.

### DIFF
--- a/juice/variant.hpp
+++ b/juice/variant.hpp
@@ -1141,14 +1141,14 @@ namespace juice
     decltype(auto)
     visit(const variant<Types...>& var, Args&&... args)
     {
-      return var.apply_visitor<MPL::false_>(*this, std::forward<Args>(args)...);
+      return var.template apply_visitor<MPL::false_>(*this, std::forward<Args>(args)...);
     }
 
     template <typename... Types, typename... Args>
     decltype(auto)
     visit(variant<Types...>& var, Args&&... args)
     {
-      return var.apply_visitor<MPL::false_>(*this, std::forward<Args>(args)...);
+      return var.template apply_visitor<MPL::false_>(*this, std::forward<Args>(args)...);
     }
 
     template <typename... Types, typename... Args>
@@ -1156,7 +1156,7 @@ namespace juice
     visit(variant<Types...>&& var, Args&&... args)
     {
       return std::move(var)
-        .apply_visitor<MPL::false_>(*this, std::forward<Args>(args)...);
+        .template apply_visitor<MPL::false_>(*this, std::forward<Args>(args)...);
     }
 
     template <int... I, typename... Args>
@@ -1196,7 +1196,7 @@ namespace juice
   auto&
   get(variant<Types...>& v)
   {
-    return v.get<I>();
+    return v.template get<I>();
   }
 
   template <size_t I, typename... Types>
@@ -1204,7 +1204,7 @@ namespace juice
   auto&
   get(const variant<Types...>& v)
   {
-    return v.get<I>();
+    return v.template get<I>();
   }
 
   template <size_t I, typename... Types>


### PR DESCRIPTION
Add missing template keyword to calls to variant::get and variant::apply_visitor,
without clang 3.7.0 refuses to compile the variant implementation.

Fixes issue #16.