### PR TITLE
emplace Fix

### DIFF
--- a/juice/variant.hpp
+++ b/juice/variant.hpp
@@ -905,40 +905,38 @@ namespace juice
     template <typename T, typename... Args>
     void emplace(Args&&... args)
     {
-      if (!valueless_by_exception())
-      {
-        destroy();
-      }
-      emplace_internal<T>(std::forward<Args>(args)...);
-      indicate_which(tuple_find<T, variant>::value);
+      return emplace<tuple_find<T, variant>::value>(std::forward<Args>(args)...);
     }
 
     template <typename T, typename U, typename... Args>
     void emplace(std::initializer_list<U> il, Args&&... args)
     {
-      if (!valueless_by_exception())
-      {
-        destroy();
-      }
-      emplace_internal<T>(il, std::forward<Args>(args)...);
-      indicate_which(tuple_find<T, variant>::value);
+      return emplace<tuple_find<T, variant>::value>(
+        il,
+        std::forward<Args>(args)...
+      );
     }
 
     template <size_t I, typename... Args>
     void emplace(Args&&... args)
     {
-      return emplace<typename std::tuple_element<I, variant>::type>(
-        std::forward<Args>(args)...
-      );
+      if (!valueless_by_exception())
+      {
+        destroy();
+      }
+      emplace_internal<typename std::tuple_element<I, variant>::type>(std::forward<Args>(args)...);
+      indicate_which(I);
     }
 
     template <size_t I, typename U, typename... Args>
     void emplace(std::initializer_list<U> il, Args&&... args)
     {
-      return emplace<typename std::tuple_element<I, variant>::type>(
-        il,
-        std::forward<Args>(args)...
-      );
+      if (!valueless_by_exception())
+      {
+        destroy();
+      }
+      emplace_internal<typename std::tuple_element<I, variant>::type>(il, std::forward<Args>(args)...);
+      indicate_which(I);
     }
 
     variant& operator=(const variant& rhs)


### PR DESCRIPTION
Referring to [P0088R0](http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2015/p0088r0.pdf), pages 20 & 21 one finds that for the overloads of emplace which take a `size_t` as their first template parameter the following postcondition is present:

>index() is I

The implementation was not respecting that, instead setting `index()` to the lowest N for which the type of the Nth parameter in the parameter pack upon which the variant was templated was equal to the type of the Ith such parameter.

To trivially reproduce this issue:

```
juice::variant<int,int> v;
v.emplace<1>(0);
std::cout << v.index() << std::endl;
```

Should print `1`, instead prints `0`.